### PR TITLE
Fix no export de trabalhos e authorize na edição de trabalhos

### DIFF
--- a/app/Exports/TrabalhosExport.php
+++ b/app/Exports/TrabalhosExport.php
@@ -15,6 +15,7 @@ class TrabalhosExport implements FromCollection, WithHeadings
     public function headings(): array
     {
         return [
+            'Id',
             'Área/Eixo',
             'Modalidade',
             'Título do trabalho',

--- a/app/Http/Requests/TrabalhoUpdateRequest.php
+++ b/app/Http/Requests/TrabalhoUpdateRequest.php
@@ -25,9 +25,9 @@ class TrabalhoUpdateRequest extends FormRequest
         $evento = $trabalho->evento;
         $mytime = Carbon::now('America/Recife');
         if (! $trabalho->modalidade->estaEmPeriodoDeSubmissao()) {
-            return $this->user()->can('isCoordenadorOrCoordenadorDasComissoes', $evento);
+            return ($this->user()->can('isCoordenadorOrCoordenadorDasComissoes', $evento) || $this->user()->can('isCoordenadorEixo', $evento));
         } else {
-            return $this->user()->can('isCoordenadorOrComissaoOrAutor', $trabalho);
+            return ($this->user()->can('isCoordenadorOrComissaoOrAutor', $trabalho)|| $this->user()->can('isCoordenadorEixo', $evento));
         }
     }
 


### PR DESCRIPTION
1. Os coordenadores de eixo não estavam conseguindo editar o trabalho quando estava fora do periodo de submissão
2. A funcionalidade de exportar os trabalhos estava estourando a memoria do servidor com 3500 trabalhos